### PR TITLE
[CI] Add crcclientdll parameter to liblist.gam (Enabled by default)

### DIFF
--- a/.github/workflows/amxx.yml
+++ b/.github/workflows/amxx.yml
@@ -163,6 +163,7 @@ jobs:
         liblist+='\ngamedll_linux "addons/metamod/dlls/metamod.so"'
         liblist+='\ngamedll_osx "dlls/hl.dylib"'
         liblist+='\nsecure "1"'
+        liblist+='\ncrcclientdll "1"'
 
         # Create liblist.gam file
         echo -e $liblist > llhl-dev-linux/ag/liblist.gam


### PR DESCRIPTION
This change is to be sure that the server won't force the player to have the same client.