### PR TITLE
Update LLHL to 1.0.1-stable

### DIFF
--- a/.github/workflows/amxx.yml
+++ b/.github/workflows/amxx.yml
@@ -163,6 +163,7 @@ jobs:
         liblist+='\ngamedll_linux "addons/metamod/dlls/metamod.so"'
         liblist+='\ngamedll_osx "dlls/hl.dylib"'
         liblist+='\nsecure "1"'
+        liblist+='\ncrcclientdll "1"'
 
         # Create liblist.gam file
         echo -e $liblist > llhl-dev-linux/ag/liblist.gam

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unlike my gamemode that I made for agmodx, this one only supports Protocol 48.
 
 ## Features
 - FPS Limiter (Default value is 144)
-- FOV Limiter (Minimum value is 85)
+- FOV Limiter (Minimum value is 85, disabled by default)
 - Records a demo automatically when a match is started (With agstart)
 - /unstuck command (10 seconds cooldown)
 - Check certain sound files, they're the same sounds that are verified in the EHLL gamemode - AG6.6
@@ -21,6 +21,7 @@ Unlike my gamemode that I made for agmodx, this one only supports Protocol 48.
 ## New cvars
 - sv_ag_fpslimit_max_fps "144"
 - sv_ag_fpslimit_max_detections "2"
+- sv_ag_min_default_fov_enabled "0"
 - sv_ag_min_default_fov "85"
 - sv_ag_cvar_check_interval "1.5"
 - sv_ag_unstuck_cooldown "10.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LLHL 1.0-stable
+# LLHL 1.0.1-stable
 This plugin is a port for Adrenaline Gamer 6.6 (And AGMini) from my [LLHL gamemode](https://github.com/rtxa/agmodx/blob/master/valve/addons/amxmodx/scripting/agmodx_llhl.sma) that was developed for rtxa's agmodx.
 Unlike my gamemode that I made for agmodx, this one only supports Protocol 48.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Unlike my gamemode that I made for agmodx, this one only supports Protocol 48.
 - Ghostmine Blocker
 - Simple OpenGF32 and AGFix detection (Through cheat commands)
 - Take screenshots at map end and occasionally when a player dies
+- Avoid abusing a ReHLDS bug (Server disappears from the masterlist when it's' paused) only when there's no game in progress.
 
 ## New cvars
 - sv_ag_fpslimit_max_fps "144"

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -164,6 +164,9 @@ public plugin_init() {
             gGhostMineBlockState = GMB_BLOCKED;
             set_cvar_num("gm_block_on", 0);
             server_print("[%s] GhostMine blocker has been deactivated", PLUGIN_ACRONYM);
+            // Try to load the default motd
+            server_cmd("motdfile motd.txt", PLUGIN_GAMEMODE);
+            server_exec();
         }
         pause("ad");
         return;
@@ -258,6 +261,10 @@ public plugin_init() {
     set_task(floatmax(1.0, get_pcvar_float(gCvarCheatCmdCheckInterval)), "OpenGFCommandRun", TASK_OPENGFCHECKER);
 
     hook_cvar_change(gCvarCheatCmdCheckInterval, "CvarCheatCmdIntervalHook");
+
+    // Load LLHL Motd
+    server_cmd("motdfile motd_llhl.txt", PLUGIN_GAMEMODE);
+    server_exec();
 }
 
 public inconsistent_file(id, const filename[], reason[64]) {

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -172,6 +172,7 @@ public plugin_init() {
     // Only ReHLDS
     if (cvar_exists("sv_rcon_condebug")) {
         register_concmd("agpause", "CmdAgpauseRehldsHook");
+        server_print("[%s] ReHLDS detected, pauses will be blocked when there are no games in progress to avoid abusing a bug.", PLUGIN_ACRONYM);
     }
     
     register_dictionary("llhl.txt");

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -1,7 +1,6 @@
 /*
     LLHL Gamemode for AG 6.6 and AGMini
     Version: 1.0.1-stable
-    Date: 28/11/20
     Author: FlyingCat
 
     # Information:

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -291,13 +291,16 @@ public client_command(id) {
             gCheatNumDetections[id]++;
             gFirstCheatValidation[id] = false;
             gSecondCheatValidation[id] = false;
-            new name[32], authID[32];
+            new name[32], authID[32], formatted[32], fileName[32];
+            new timestamp = get_systime();
+            format_time(formatted, charsmax(formatted), "%d%m%Y", timestamp);
+            formatex(fileName, charsmax(fileName), "llhl_detections_%s.log", formatted);
             get_user_name(id, name, charsmax(name));
             get_user_authid(id, authID, charsmax(authID));
-            log_to_file("llhl_detections.log", "[%s - Simple Cheat Detector] %s (%s) has been detected a possible use of OpenGF32/AGFix. Remaining attemps: %i/%i", PLUGIN_ACRONYM, name, authID, gCheatNumDetections[id], get_pcvar_num(gCvarCheatCmdMaxDetections));
+            log_to_file(fileName, "[%s - Simple Cheat Detector] %s (%s) has been detected a possible use of OpenGF32/AGFix. Remaining attemps: %i/%i", PLUGIN_ACRONYM, name, authID, gCheatNumDetections[id], get_pcvar_num(gCvarCheatCmdMaxDetections));
 
             if (gCheatNumDetections[id] >= get_pcvar_num(gCvarCheatCmdMaxDetections)) {
-                log_to_file("llhl_detections.log", "[%s - Simple Cheat Detector] %s (%s) has been detected OpenGF32/AGFix after %i attempts", PLUGIN_ACRONYM, name, authID, gCheatNumDetections[id]);
+                log_to_file(fileName, "[%s - Simple Cheat Detector] %s (%s) has been detected OpenGF32/AGFix after %i attempts", PLUGIN_ACRONYM, name, authID, gCheatNumDetections[id]);
                 gCheatNumDetections[id] = 0;
             }
         }

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -171,7 +171,7 @@ public plugin_init() {
 
     // Only ReHLDS
     if (cvar_exists("sv_rcon_condebug")) {
-        register_concmd("agpause", "CmdAgpauseRehldsHook");
+        register_clcmd("agpause", "CmdAgpauseRehldsHook");
         server_print("[%s] ReHLDS detected, pauses will be blocked when there are no games in progress to avoid abusing a bug.", PLUGIN_ACRONYM);
     }
     
@@ -619,9 +619,9 @@ public CmdAgpauseRehldsHook(id) {
         get_user_name(id, name, charsmax(name));
         get_user_authid(id, authID, charsmax(authID));
         log_to_file(fileName, "[%s] %s (%s) tried to pause the server when no one else was around. Possible ReHLDS Bug Exploit", PLUGIN_ACRONYM, name, authID);
-        return FMRES_SUPERCEDE;
+        return PLUGIN_HANDLED;
     }
-    return FMRES_IGNORED;
+    return PLUGIN_CONTINUE;
 }
 
 public CvarGhostMineHook(pcvar, const old_value[], const new_value[]) {

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -519,6 +519,7 @@ public FovCheckReturn(id, const cvar[], const value[]) {
     } else if (equali(cvar, "default_fov") && str_to_num(value) < min(85, get_pcvar_num(gCvarMinFov))) {
         static name[MAX_NAME_LENGTH];
         get_user_name(id, name, charsmax(name));
+        console_cmd(id, "default_fov %d", 90);
         server_cmd("kick #%d ^"%L^"", get_user_userid(id), id, "MINFOV_KICK", get_pcvar_num(gCvarMinFov));
         log_amx("%L", LANG_SERVER, "MINFOV_KICK_MSG", name, get_pcvar_num(gCvarMinFov));
         client_print(0, print_chat, "%l", "MINFOV_KICK_MSG", name, get_pcvar_num(gCvarMinFov));

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -1,7 +1,7 @@
 /*
     LLHL Gamemode for AG 6.6 and AGMini
-    Version: 1.0-stable
-    Date: 20/11/20
+    Version: 1.0.1-stable
+    Date: 28/11/20
     Author: FlyingCat
 
     # Information:
@@ -60,7 +60,7 @@
 #define PLUGIN          "Liga Latinoamericana de Half Life"
 #define PLUGIN_ACRONYM  "LHLL"
 #define PLUGIN_GAMEMODE "llhl"
-#define VERSION         "1.0-stable"
+#define VERSION         "1.0.1-stable"
 #define AUTHOR          "FlyingCat"
 
 #pragma semicolon 1

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -10,7 +10,7 @@
 
     # Features:
     - FPS Limiter (Default value is 144)
-    - FOV Limiter (Minimum value is 85)
+    - FOV Limiter (Minimum value is 85, disabled by default)
     - Records a demo automatically when a match is started (With agstart)
     - /unstuck command (10 seconds cooldown)
     - Check certain sound files, they're the same sounds that are verified in the 
@@ -28,6 +28,7 @@
     # New cvars:
     - sv_ag_fpslimit_max_fps "144"
     - sv_ag_fpslimit_max_detections "2"
+    - sv_ag_min_default_fov_enabled "0"
     - sv_ag_min_default_fov "85"
     - sv_ag_cvar_check_interval "1.5"
     - sv_ag_unstuck_cooldown "10.0"
@@ -99,6 +100,7 @@ new gDeathScreenshotTaken[MAX_PLAYERS + 1];
 new gCvarAgStartMinPlayers;
 new gCvarMaxFps;
 new gCvarMaxDetections;
+new gCvarMinFovEnabled;
 new gCvarMinFov;
 new gCvarCheckInterval;
 new gCvarUnstuckCooldown;
@@ -180,7 +182,8 @@ public plugin_init() {
     gCvarMaxFps = create_cvar("sv_ag_fpslimit_max_fps", "144");
     gCvarMaxDetections = create_cvar("sv_ag_fpslimit_max_detections", "2");
 
-    // Mininum Default Fov Allowed
+    // Mininum Default Fov Allowed (Disabled by default)
+    gCvarMinFovEnabled = create_cvar("sv_ag_min_default_fov_enabled", "0");
     gCvarMinFov = create_cvar("sv_ag_min_default_fov", "85");
 
     // CVAR Checker Interval (FPS and Fov)
@@ -498,7 +501,9 @@ public CvarCheckRun() {
             CheckHLTVDelay(players[i]);
         } else if (!hl_get_user_spectator(players[i])) {
             query_client_cvar(players[i], "fps_max", "FpsCheckReturn");
-            query_client_cvar(players[i], "default_fov", "FovCheckReturn");
+            if (get_pcvar_num(gCvarMinFovEnabled)) {
+                query_client_cvar(players[i], "default_fov", "FovCheckReturn");
+            }
         }
     }
     set_task(floatmax(1.0, get_pcvar_float(gCvarCheckInterval)), "CvarCheckRun", TASK_CVARCHECKER);

--- a/ag/gamemodes/llhl.cfg
+++ b/ag/gamemodes/llhl.cfg
@@ -104,6 +104,7 @@ sv_ag_dmg_m203              "100"
 
 sv_ag_fpslimit_max_fps          "144"
 sv_ag_fpslimit_max_detections   "2"
+sv_ag_min_default_fov_enabled   "0"
 sv_ag_min_default_fov           "85"
 sv_ag_cvar_check_interval       "1.5"
 sv_ag_unstuck_cooldown          "10.0"

--- a/ag/motd_llhl.txt
+++ b/ag/motd_llhl.txt
@@ -1,0 +1,34 @@
+Bienvenido al modo de juego LLHL v1.0.1-stable
+Este modo de juego se usa actualmente para la Liga Latinoamericana de Half-Life (LLHL)
+
+-- Nuevas caracteristicas --
+# Limitador de FPS (El valor por defecto es 144)
+# Bloqueo de valores de 'default_fov' bajos (El valor por defecto es 85, caracteristica desactivada por defecto)
+# Graba demos automaticamente cuando se inicia una partida (Con agstart)
+# Nuevo comando: /unstuck (10 segundos de enfriamiento)
+# Verificacion de sonidos
+# Destruir los satchels de otros players (Caracteristica desactivada por defecto)
+# Bloqueo de cambios de name y model cuando una partida esta en progreso (Opcionales, ambas caracteristicas activadas por defecto)
+# Nuevo modo de intermision
+# Forzar al HLTV a tener una cantidad de delay como minimo (El valor como minimo es 30)
+# Bloqueador de Wallhack
+# Bloqueador de Ghostmine (Opcional, caracteristica activada por defecto)
+# Simple deteccion de los cheats OpenGF32 y AGFix
+# Captura de pantallas al terminar el mapa y ocasionalmente cuando un jugador muere
+
+-- Configuracion del modo de juego --
+# Forzado de respawn activado
+# RPG Fix activado
+# Gauss Fix activado
+# Daño de la egon reducido en un 35%
+# Daño de la crowbar aumentado en un 30%
+# Daño de la hornetgun aumentado en un 30%
+
+Ten guardado todas tus capturas de pantalla y demos generadas con este modo de juego.
+Un administrador podria pedirte que las subas.
+
+-- Informacion del modo de juego --
+# Version: 1.0.1-stable
+# Autor: FlyingCat (Discord: Suisei#9999)
+# Repositorio: https://git.io/jkttq
+# Descarga: https://github.com/FlyingCat-X/llhl/releases/latest


### PR DESCRIPTION
- Add crcclientdll parameter to liblist.gam (Enabled by default)
- Before kicking the player for having less 'default_fov' than allowed, modify the value to 90 (If possible)
- Make detection logs per day
- Add new cvar sv_ag_min_default_fov_enabled (Disabled by default)
- Add custom motd for LLHL Gamemode