### PR TITLE
Remove WHBlocker from future releases

### DIFF
--- a/.github/workflows/amxx.yml
+++ b/.github/workflows/amxx.yml
@@ -129,14 +129,6 @@ jobs:
         cp metamod/*.so llhl-dev-linux/ag/addons/metamod/dlls
         cp metamod/*.dll llhl-dev-windows/ag/addons/metamod/dlls
 
-        # Copy WHBlocker to metamod plugins folder
-        cp llhl-resources/metamod-plugins/whblocker-1.5.697/*.so llhl-dev-linux/ag/addons/metamod/dlls
-        cp llhl-resources/metamod-plugins/whblocker-1.5.697/*.dll llhl-dev-windows/ag/addons/metamod/dlls
-        
-        # Copy WHBlocker CFG File (Windows and Linux)
-        cp llhl-resources/metamod-plugins/whblocker-1.5.697/config.ini llhl-dev-linux/ag/addons/metamod/dlls
-        cp llhl-resources/metamod-plugins/whblocker-1.5.697/config.ini llhl-dev-windows/ag/addons/metamod/dlls
-
         # Copy GhostMineBlock to metamod plugins folder
         cp llhl-resources/metamod-plugins/ghostmineblock-1.5/*.so llhl-dev-linux/ag/addons/metamod/dlls
         cp llhl-resources/metamod-plugins/ghostmineblock-1.5/*.dll llhl-dev-windows/ag/addons/metamod/dlls
@@ -148,11 +140,9 @@ jobs:
         cp llhl-resources/amxx-related/gRIP/configs/*.ini llhl-dev-windows/ag/addons/amxmodx/configs
 
         # Add amxmodx to metamod plugins
-        metamodPluginsLinux='linux addons/metamod/dlls/whblocker_mm_i386.so'
         metamodPluginsLinux+='\nlinux addons/metamod/dlls/gm_block_mm_i386.so'
         metamodPluginsLinux+='\nlinux addons/amxmodx/dlls/amxmodx_mm_i386.so'
 
-        metamodPluginsWin='win32 addons/metamod/dlls/whblocker_mm.dll'
         metamodPluginsWin+='\nwin32 addons/metamod/dlls/gm_block_mm.dll'
         metamodPluginsWin+='\nwin32 addons/amxmodx/dlls/amxmodx_mm.dll'
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ If you have any problem in your server, before opening an issue or contacting me
 - New intermission mode.
 - More than 1 HLTV allowed.
 - Force connected HLTV to have a certain delay value as a minimum (Minimum value is 30).
-- Wallhack Blocker.
 - Ghostmine Blocker.
 - Simple OpenGF32 and AGFix detection (Through cheat commands).
 - Take screenshots at map end and occasionally when a player dies.

--- a/README_ES.md
+++ b/README_ES.md
@@ -16,7 +16,6 @@ Si tienes algún problema en tu servidor, antes de abrir una issue o contactarme
 - No se permiten cambios de nombre y model cuando hay una partida en curso (Opcional, ambos activados por defecto).
 - Nuevo modo de espera al finalizar un mapa.
 - Se fuerza al HLTV conectado a tener un cierto valor de delay como mínimo (Valor mínimo por defecto es 30).
-- Bloqueador de wallhack.
 - Bloqueador de ghostmines.
 - Detección simple de OpenGF32 y AGFix (Mediante comandos del cheat).
 - Toma screenshots al termino de un mapa y ocasionalmente cuando un jugador muere.

--- a/README_PT.md
+++ b/README_PT.md
@@ -15,7 +15,6 @@ Se tiver um problema no seu servidor antes de abrir uma issue ou entrar em conta
 - Não são permitidas mudanças de nome e model quando um jogo está em andamento (opcional ambos ativados por padrão).
 - Novo modo de espera ao terminar um mapa.
 - Es forçado a ter HLTV conectado um certo valor de delay pelo mínimo (o valor padrão mínimo é 30).
-- Bloqueador de wallhack.
 - Bloqueador de ghostmines.
 - Detecção simples de OpenGF32 e AGFix (Atraves do comandos do cheat)
 - Faça screenshots no final de um mapa e ocasionalmente quando um jogador morre.

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -20,7 +20,6 @@
     - New intermission mode
     - More than 1 HLTV allowed
     - Force connected HLTV to have a certain delay value as a minimum (Minimum value is 30)
-    - Wallhack Blocker
     - Ghostmine Blocker
     - Simple OpenGF32 and AGFix detection (Through cheat commands)
     - Take screenshots at map end and occasionally when a player dies


### PR DESCRIPTION
Starting from version v1.2-stable, the distribution of WHBlocker together with LLHL will be discontinued as it generates problems.
Since this plugin is currently being used in a LA AG League a minimum of 50% approval is required for this PR to proceed.
Teams asked:
- [x] **GDM-A -> Agrees**
- [x] **GDM-B -> Agrees**
- [x] _Game@Force -> They weren't asked because the necessary votes were reached_
- [x] [Matrer0s] -> Disagrees
- [x] **[Zomb!E] -> Agrees**
- [x] PTK -> Disagrees
- [x] **Ad.e -> Agrees**
- [x] **OneShoT -> Agrees**
- [x] **Akatsuki -> Agrees**
- [x] **DM.T -> Agrees**
- [x] **[AoG] -> Agrees**
- [x] [Matrer0s-Jr] -> Disagrees
- [x] _RvL -> They weren't asked because the necessary votes were reached_
- [x] mTz -> Disagrees
- [x] _Legendary -> They weren't asked because the necessary votes were reached_

**Votes required: 8/8**