### PR TITLE
Add llhl_match_manager command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you have any problem in your server, before opening an issue or contacting me
 - Changing model during a match subtract 1 from the score. (Optional, enabled by default).
 - Block access to players who have the game via Family Sharing. (Optional, disabled by default).
 - Check for new updates and it will download them automatically.
+- llhl_match_manager command (For administrators only)
 
 ## New cvars
 - sv_ag_fpslimit_max_fps "144"

--- a/README_ES.md
+++ b/README_ES.md
@@ -23,6 +23,7 @@ Si tienes algún problema en tu servidor, antes de abrir una issue o contactarme
 - Cambiar de model durante una partida resta 1 de la puntuación. (Opcional, por defecto está activado).
 - Bloquear el acceso a los jugadores que tengan el juego vía prestamo familiar. (Opcional, por defecto está desactivado).
 - Verifica si hay nuevas actualizaciones y las descargará automáticamente.
+- Comando llhl_match_manager implementado (Solo para administradores)
 
 ## Nuevas cvars
 - sv_ag_fpslimit_max_fps "144"

--- a/README_PT.md
+++ b/README_PT.md
@@ -22,6 +22,7 @@ Se tiver um problema no seu servidor antes de abrir uma issue ou entrar em conta
 - A mudança de model durante uma partida subtrai 1 da pontuação. (Opcional, por padrão está activado).
 - Bloquear o acesso aos jogadores que têm o jogo através do compartilhamento de bibliotecas.
 - Verifica se há novas actualizações e vai baixar automaticamente.
+- Comando llhl_match_manager implementado (Apenas para administradores)
 
 ## Novas cvars
 - sv_ag_fpslimit_max_fps "144"

--- a/ag/addons/amxmodx/data/lang/llhl.txt
+++ b/ag/addons/amxmodx/data/lang/llhl.txt
@@ -47,6 +47,16 @@ LLHL_SCD_DETECTION = [%s - Simple Cheat Detector] %s (%s) has been detected Open
 LLHL_REHLDS_XPLOIT = [%s] %s (%s) tried to pause the server when no one else was around. Possible ReHLDS Bug Exploit
 LLHL_IS_OUTDATED = [%s] This server uses an outdated version of the gamemode.
 LLHL_SP_AGSTART_NOT_ENOUGH = [%s] Not enough players found to start a game.
+LLHL_MM_MENU_MAIN_TITLE = LLHL Match Manager | Main Menu
+LLHL_MM_ITEM_MAIN_2 = Select the match type: [%s]
+LLHL_MM_ITEM_MAIN_3 = Assign players: Blue [%i-%i] Red
+LLHL_MM_ITEM_MAIN_4 = Start match
+LLHL_MM_MENU_IN_USE = The menu is currently in use. Try again later.
+LLHL_MM_OPT_2_TITLE = Match type:
+LLHL_MM_OPT_3_TITLE = Assigning players:
+LLHL_MM_NO_MATCH_TYPE = No match type has been selected.
+LLHL_MM_MATCH_ALREADY_STARTED = A game is starting. Try again later.
+LLHL_MM_INVALID_PLAYER_COUNT = The number of players selected isn't correct.
 
 [es]
 CVAR_PROTECTOR_KICK = Bloqueador/Protector de CVAR Detectado
@@ -97,6 +107,16 @@ LLHL_SCD_DETECTION = [%s - Simple Cheat Detector] A %s (%s) se le ha detectado O
 LLHL_REHLDS_XPLOIT = [%s] %s (%s) trato de pausar el servidor cuando no habia nadie alrededor. Possible exploit de bug del ReHLDS
 LLHL_IS_OUTDATED = [%s] Este servidor usa una version desactualizada del modo de juego.
 LLHL_SP_AGSTART_NOT_ENOUGH = [%s] No se encontro suficientes jugadores para iniciar una partida.
+LLHL_MM_MENU_MAIN_TITLE = LLHL Gestor de partidas | Menu principal
+LLHL_MM_ITEM_MAIN_2 = Seleccione el tipo de partida: [%s]
+LLHL_MM_ITEM_MAIN_3 = Asignar jugadores: Blue [%i-%i] Red
+LLHL_MM_ITEM_MAIN_4 = Iniciar partida
+LLHL_MM_MENU_IN_USE = El menú está siendo usado actualmente. Inténtalo nuevamente luego.
+LLHL_MM_OPT_2_TITLE = Tipo de partida:
+LLHL_MM_OPT_3_TITLE = Asignando jugadores:
+LLHL_MM_NO_MATCH_TYPE = No se ha seleccionado un tipo de partida.
+LLHL_MM_MATCH_ALREADY_STARTED = Una partida se está iniciando. Inténtalo nuevamente luego.
+LLHL_MM_INVALID_PLAYER_COUNT = La cantidad de jugadores seleccionados no es la correcta.
 
 [pt]
 CVAR_PROTECTOR_KICK = Bloqueador/Protetor de CVAR Detectado
@@ -147,6 +167,16 @@ LLHL_SCD_DETECTION = [%s - Simple Cheat Detector] %s (%s) foi detectado OpenGF32
 LLHL_REHLDS_XPLOIT = [%s] %s (%s) tentou fazer uma pausa no servidor quando mais ninguém estava por perto. Possível ReHLDS Bug Exploit
 LLHL_IS_OUTDATED = [%s] Este servidor utiliza uma versão desactualizada do modo de jogo.
 LLHL_SP_AGSTART_NOT_ENOUGH = [%s] Não foram encontrados jogadores suficientes para iniciar um jogo.
+LLHL_MM_MENU_MAIN_TITLE = LLHL Gestor de jogos | Menu principal
+LLHL_MM_ITEM_MAIN_2 = Seleccionar o tipo de jogo: [%s]
+LLHL_MM_ITEM_MAIN_3 = Designar jogadores: Blue [%i-%i] Red
+LLHL_MM_ITEM_MAIN_4 = Iniciar jogo
+LLHL_MM_MENU_IN_USE = O menu está actualmente em uso. Tente novamente mais tarde.
+LLHL_MM_OPT_2_TITLE = Tipo de jogo:
+LLHL_MM_OPT_3_TITLE = Designação de jogadores:
+LLHL_MM_NO_MATCH_TYPE = Não foi seleccionado nenhum tipo de jogo.
+LLHL_MM_MATCH_ALREADY_STARTED = Um jogo está a começar. Tente novamente mais tarde.
+LLHL_MM_INVALID_PLAYER_COUNT = O número de jogadores seleccionados não é o correcto.
 
 [cn]
 CVAR_PROTECTOR_KICK = 检测到参数限制器.
@@ -197,3 +227,13 @@ LLHL_SCD_DETECTION = [%s - 作弊检测] %s (%s) 经过了%i次尝试后被检�
 LLHL_REHLDS_XPLOIT = [%s] %s (%s) 尝试在没有人的时候暂停服务器, 可能是rehlds漏洞攻击.
 LLHL_IS_OUTDATED = [%s] 此服务器正在使用旧的游戏模式..
 LLHL_SP_AGSTART_NOT_ENOUGH = [%s] 没有找到足够的球员来开始游戏.
+LLHL_MM_MENU_MAIN_TITLE = LLHL 比赛经理  | 主菜单
+LLHL_MM_ITEM_MAIN_2 = 选择匹配类型: [%s]
+LLHL_MM_ITEM_MAIN_3 = 指派球员: Blue [%i-%i] Red
+LLHL_MM_ITEM_MAIN_4 = 开始比赛
+LLHL_MM_MENU_IN_USE = 此菜单当前正在使用中. 稍后再试.
+LLHL_MM_OPT_2_TITLE = 比赛类型:
+LLHL_MM_OPT_3_TITLE = 指派球员:
+LLHL_MM_NO_MATCH_TYPE = 未选择匹配类型.
+LLHL_MM_MATCH_ALREADY_STARTED = 一个游戏正在开始。稍后再试.
+LLHL_MM_INVALID_PLAYER_COUNT = 被选中的球员数量并不正确.

--- a/ag/addons/amxmodx/data/lang/llhl.txt
+++ b/ag/addons/amxmodx/data/lang/llhl.txt
@@ -46,6 +46,7 @@ LLHL_SCD_POSSIBLE_DETECTION = [%s - Simple Cheat Detector] %s (%s) has been dete
 LLHL_SCD_DETECTION = [%s - Simple Cheat Detector] %s (%s) has been detected OpenGF32/AGFix after %i attempts
 LLHL_REHLDS_XPLOIT = [%s] %s (%s) tried to pause the server when no one else was around. Possible ReHLDS Bug Exploit
 LLHL_IS_OUTDATED = [%s] This server uses an outdated version of the gamemode.
+LLHL_SP_AGSTART_NOT_ENOUGH = [%s] Not enough players found to start a game.
 
 [es]
 CVAR_PROTECTOR_KICK = Bloqueador/Protector de CVAR Detectado
@@ -95,6 +96,7 @@ LLHL_SCD_POSSIBLE_DETECTION = [%s - Simple Cheat Detector] A %s (%s) se le ha de
 LLHL_SCD_DETECTION = [%s - Simple Cheat Detector] A %s (%s) se le ha detectado OpenGF32/AGFix despues de %i intentos
 LLHL_REHLDS_XPLOIT = [%s] %s (%s) trato de pausar el servidor cuando no habia nadie alrededor. Possible exploit de bug del ReHLDS
 LLHL_IS_OUTDATED = [%s] Este servidor usa una version desactualizada del modo de juego.
+LLHL_SP_AGSTART_NOT_ENOUGH = [%s] No se encontro suficientes jugadores para iniciar una partida.
 
 [pt]
 CVAR_PROTECTOR_KICK = Bloqueador/Protetor de CVAR Detectado
@@ -144,6 +146,7 @@ LLHL_SCD_POSSIBLE_DETECTION = [%s - Simple Cheat Detector] %s (%s) foi detectada
 LLHL_SCD_DETECTION = [%s - Simple Cheat Detector] %s (%s) foi detectado OpenGF32/AGFix após %i tentativas
 LLHL_REHLDS_XPLOIT = [%s] %s (%s) tentou fazer uma pausa no servidor quando mais ninguém estava por perto. Possível ReHLDS Bug Exploit
 LLHL_IS_OUTDATED = [%s] Este servidor utiliza uma versão desactualizada do modo de jogo.
+LLHL_SP_AGSTART_NOT_ENOUGH = [%s] Não foram encontrados jogadores suficientes para iniciar um jogo.
 
 [cn]
 CVAR_PROTECTOR_KICK = 检测到参数限制器.
@@ -192,4 +195,5 @@ LLHL_UPDATE_DL_FAILED = [%s] 插件更新失败.
 LLHL_SCD_POSSIBLE_DETECTION = [%s - 作弊检测] %s (%s) 已检测到可能使用了 OpenGF32/AGFix | 剩余检测次数: %i/%i
 LLHL_SCD_DETECTION = [%s - 作弊检测] %s (%s) 经过了%i次尝试后被检测到使用了 OpenGF32/AGFix
 LLHL_REHLDS_XPLOIT = [%s] %s (%s) 尝试在没有人的时候暂停服务器, 可能是rehlds漏洞攻击.
-LLHL_IS_OUTDATED = [%s] 此服务器正在使用旧的游戏模式.
+LLHL_IS_OUTDATED = [%s] 此服务器正在使用旧的游戏模式..
+LLHL_SP_AGSTART_NOT_ENOUGH = [%s] 没有找到足够的球员来开始游戏.

--- a/ag/addons/amxmodx/scripting/llhl.sma
+++ b/ag/addons/amxmodx/scripting/llhl.sma
@@ -28,6 +28,7 @@
     - Block access to players who have the game via Family Sharing. (Optional, disabled by default).
     - Random spawns (Optional, disabled by default)
     - Check for new updates and it will download them automatically.
+    - llhl_match_manager command (For administrators only)
 
     # New cvars:
     - sv_ag_fpslimit_max_fps "144"
@@ -112,6 +113,11 @@
 #define GMB_LOADED      1 // Reserved for future use
 #define GMB_BLOCKED     2 // Reserved for future use
 
+// MM: Match Manager
+#define MM_NO_TEAM      "NO"
+#define MM_BLUE_TEAM    "BLUE"
+#define MM_RED_TEAM     "RED"
+
 #define GAME_APPID      70
 
 enum (+=103) {
@@ -184,8 +190,6 @@ new Array:gListPaths;
 new Array:gSpawnOrigins, Array:gSpawnAngles;
 new gSpawnsCounter;
 
-new Array:gPlayersAllowed;
-
 new gCheckUpdatesNumRetrys;
 new gRepoVersion[32];
 new gSvPasswordPreUpdate[64];
@@ -193,6 +197,12 @@ new bool:gIsOutdated = false;
 
 new gDownloadRetries;
 new gDownloadCounter;
+
+// MM: Match Manager
+new gMMVersusType[2];
+new gMMMenuOwner;
+
+new Trie:gMMUserIDPlayers;
 
 new const gConsistencySoundFiles[][] = {
     "ambience/pulsemachine.wav",
@@ -350,9 +360,9 @@ public plugin_init() {
     register_clcmd("hash", "CmdSHA1Hash");
     register_clcmd("say /hash", "CmdSHA1Hash");
 
-    register_concmd("special_agstart", "SpecialAgstart", ADMIN_ALL);
+    gMMUserIDPlayers = TrieCreate();
 
-    gPlayersAllowed = ArrayCreate(64);
+    register_clcmd("llhl_match_manager", "MatchManagerMenu", ADMIN_BAN);
     
     // AG Messages
     register_message(get_user_msgid("Countdown"), "FwMsgCountdown");
@@ -430,6 +440,22 @@ public client_connect(id) {
     gCheatNumDetections[id] = 0;
     gFirstCheatValidation[id] = false;
     gSecondCheatValidation[id] = false;
+
+    new userID[8];
+    num_to_str(get_user_userid(id), userID, charsmax(userID));
+
+    if (!TrieKeyExists(gMMUserIDPlayers, userID)) {
+        TrieSetString(gMMUserIDPlayers, userID, MM_NO_TEAM);
+    }
+}
+
+public client_disconnected(id) {
+    new userID[8];
+    num_to_str(get_user_userid(id), userID, charsmax(userID));
+
+    if (TrieKeyExists(gMMUserIDPlayers, userID)) {
+        TrieDeleteKey(gMMUserIDPlayers, userID);
+    }
 }
 
 public client_putinserver(id) {
@@ -1309,62 +1335,217 @@ public LoadSpawns() {
     }
 }
 
-public SpecialAgstart(id, level, cid) {
-    if (get_playersnum() >= get_pcvar_num(gCvarAgStartMinPlayers)) {
-        if (read_argc() < 2) {
+public MatchManagerMenu(id) {
+    if (!gMMMenuOwner || id == gMMMenuOwner) {
+        gMMMenuOwner = id;
+
+        new multilangString[64];
+
+        formatex(multilangString, charsmax(multilangString), "%L", LANG_PLAYER, "LLHL_MM_MENU_MAIN_TITLE");
+        new managerMenu = menu_create(multilangString, "MatchManagerHandler");
+
+        new versusType[8];
+        if (!gMMVersusType[0]) {
+            versusType = "N/A";
+        } else {
+            formatex(versusType, charsmax(versusType), "%svs%s", gMMVersusType, gMMVersusType);
+        }
+        formatex(multilangString, charsmax(multilangString), "%L", LANG_PLAYER, "LLHL_MM_ITEM_MAIN_2", versusType);
+        menu_additem(managerMenu, multilangString, "", ADMIN_BAN);
+
+        formatex(multilangString, charsmax(multilangString), "%L", LANG_PLAYER, "LLHL_MM_ITEM_MAIN_3", GetPlayersNumInTeam(MM_BLUE_TEAM), GetPlayersNumInTeam(MM_RED_TEAM));
+        menu_additem(managerMenu, multilangString, "", ADMIN_BAN);
+
+        formatex(multilangString, charsmax(multilangString), "%L", LANG_PLAYER, "LLHL_MM_ITEM_MAIN_4");
+        menu_additem(managerMenu, multilangString, "", ADMIN_BAN);
+
+        menu_display(id, managerMenu, 0);
+    } else {
+        client_print(id, print_chat, "%l", "LLHL_MM_MENU_IN_USE");
+    }
+}
+
+public MatchManagerHandler(id, menu, item) {
+    menu_destroy(menu);
+    switch (item) {
+        case 0: {
+            MatchManagerVersusTypeMenu(id);
             return PLUGIN_HANDLED;
         }
-
-        new authID[64];
-        new Regex:gAuthIDPattern;
-
-        gAuthIDPattern = regex_compile("STEAM_[01]:[01]:\d+");
-        for (new i = 1; i <= read_argc() - 1; i++) {
-            read_argv(i, authID, charsmax(authID));
-
-            // REGEX_NO_MATCH (Its value is 0) gives me tag mismatch for some reason
-            if (regex_match_c(authID, gAuthIDPattern) > 0 && find_player_ex(FindPlayer_MatchAuthId, authID)) {
-                ArrayPushString(gPlayersAllowed, authID);
-                server_print(authID);
-            }
+        case 1: {
+            MatchManagerAssignPlayersMenu(id);
+            return PLUGIN_HANDLED;
         }
-        regex_free(gAuthIDPattern);
-        
-        if (ArraySize(gPlayersAllowed) >= get_pcvar_num(gCvarAgStartMinPlayers)) {
-            server_cmd("agabort");
-
-            new tempAuthID[32];
-            for (new id = 1; id <= MaxClients; id++) {
-                get_user_authid(id, tempAuthID, charsmax(tempAuthID));
-                new player = ArrayFindString(gPlayersAllowed, tempAuthID);
-                if (player == -1) {
-                    client_cmd(id, "spectate");
-                }
-            }
-            
-            server_cmd("agstart");
-        } else {
-            if (IsUserServer(id)) {
-                server_print("%L", LANG_SERVER, "LLHL_SP_AGSTART_NOT_ENOUGH");
-            } else {
-                client_print(id, print_chat, "%l", "LLHL_SP_AGSTART_NOT_ENOUGH");
-            }
+        case 2: {
+            MatchManagerStartMatch(id);
+            return PLUGIN_HANDLED;
         }
     }
+    CleanMenuData();
     return PLUGIN_HANDLED;
 }
 
-public IsUserServer(id) {
-    if (is_dedicated_server()) {
-        if (!id) {
-            return true;
-        }
-    } else {
-        new ip[MAX_IP_LENGTH];
-        get_user_ip(id, ip, charsmax(ip), true);
-        if (equal(ip, "loopback")) {
-            return true;
+public MatchManagerVersusTypeMenu(id) {
+    new multilangString[64];
+
+    formatex(multilangString, charsmax(multilangString), "%L", LANG_PLAYER, "LLHL_MM_OPT_2_TITLE");
+    new versusMenu = menu_create(multilangString, "MatchManagerVersusTypeHandler");
+
+    new menuDescription[8];
+    new typeString[2];
+    for (new i = 1; i <= 6; i++) {
+        formatex(menuDescription, charsmax(menuDescription), "%ivs%i", i, i);
+        formatex(typeString, charsmax(typeString), "%i", i);
+        menu_additem(versusMenu, menuDescription, typeString, ADMIN_BAN);
+    }
+    
+    menu_display(id, versusMenu, 0);
+}
+
+public MatchManagerVersusTypeHandler(id, menu, item) {
+    if (item >= 0 && item <= 5) {
+        new data[6], name[64];
+        new access, itemCallback;
+
+        menu_item_getinfo(menu, item, access, data, charsmax(data), name, charsmax(name), itemCallback);
+        copy(gMMVersusType, charsmax(gMMVersusType), data);
+    }
+
+    menu_destroy(menu);
+    MatchManagerMenu(id);
+
+    return PLUGIN_HANDLED;
+}
+
+public MatchManagerAssignPlayersMenu(id) {
+    new multilangString[64];
+
+    formatex(multilangString, charsmax(multilangString), "%L", LANG_PLAYER, "LLHL_MM_OPT_3_TITLE");
+    new playersMenu = menu_create(multilangString, "MatchManagerAssignPlayersHandler");
+
+    new TrieIter:iterator = TrieIterCreate(gMMUserIDPlayers); {
+        new key[32];
+        new value[8], valueLength;
+
+        new target;
+        new username[MAX_NAME_LENGTH + 1];
+
+        new menuDescription[128];
+
+        while (!TrieIterEnded(iterator)) {
+            TrieIterGetKey(iterator, key, charsmax(key));
+            TrieIterGetString(iterator, value, charsmax(value), valueLength);
+
+            if ((target = find_player("k", str_to_num(key)))) {
+                get_user_name(target, username, charsmax(username));
+                formatex(menuDescription, charsmax(menuDescription), "%s [%s]", username, value);
+                menu_additem(playersMenu, menuDescription, key, ADMIN_BAN);
+            }
+            TrieIterNext(iterator);
         }
     }
-    return false;
+    TrieIterDestroy(iterator);
+
+    menu_display(id, playersMenu, 0);
+}
+
+public MatchManagerAssignPlayersHandler(id, menu, item) {
+    if (item == MENU_EXIT) {
+        menu_destroy(menu);
+        MatchManagerMenu(id);
+        return PLUGIN_HANDLED;
+	}
+
+    new data[6], name[64];
+    new access, itemCallback;
+    
+    menu_item_getinfo(menu, item, access, data, charsmax(data), name, charsmax(name), itemCallback);
+
+    new team[8];
+    TrieGetString(gMMUserIDPlayers, data, team, charsmax(team));
+
+    if (equali(team, MM_NO_TEAM)) {
+        TrieSetString(gMMUserIDPlayers, data, MM_BLUE_TEAM);
+    } else if (equali(team, MM_BLUE_TEAM)) {
+        TrieSetString(gMMUserIDPlayers, data, MM_RED_TEAM);
+    } else if (equali(team, MM_RED_TEAM)) {
+        TrieSetString(gMMUserIDPlayers, data, MM_NO_TEAM);
+    }
+
+    menu_destroy(menu);
+    MatchManagerAssignPlayersMenu(id);
+    return PLUGIN_HANDLED;
+}
+
+public MatchManagerStartMatch(id) {
+    if (!gMMVersusType[0]) {
+        client_print(id, print_chat, "%l", "LLHL_MM_NO_MATCH_TYPE");
+        MatchManagerMenu(id);
+    } else if (gGameState == GAME_STARTING) {
+        client_print(id, print_chat, "%l", "LLHL_MM_MATCH_STARTING");
+        MatchManagerMenu(id);
+    } else {
+        if (GetPlayersNumInTeam(MM_BLUE_TEAM) == str_to_num(gMMVersusType) && GetPlayersNumInTeam(MM_RED_TEAM) == str_to_num(gMMVersusType)) {
+            new TrieIter:iterator = TrieIterCreate(gMMUserIDPlayers); {
+                new key[32];
+                new value[8], valueLength;
+                
+                new target;
+                while (!TrieIterEnded(iterator)) {
+                    TrieIterGetKey(iterator, key, charsmax(key));
+                    if ((target = find_player("k", str_to_num(key)))) {
+                        TrieIterGetString(iterator, value, charsmax(value), valueLength);
+                        if (!equali(value, MM_NO_TEAM)) {
+                            strtolower(value);
+                            client_cmd(target, "model %s", value);
+                        } else {
+                            if (!hl_get_user_spectator(id)) {
+                                client_cmd(target, "spectate");
+                            }
+                        }
+                    }
+                    TrieIterNext(iterator);
+                }
+            }
+            CleanMenuData();
+            server_cmd("agstart");
+            
+            TrieIterDestroy(iterator);
+        } else {
+            client_print(id, print_chat, "%l", "LLHL_MM_INVALID_PLAYER_COUNT");
+            MatchManagerMenu(id);
+        }
+    }
+}
+
+public GetPlayersNumInTeam(team[]) {
+    new counter;
+    new TrieIter:iterator = TrieIterCreate(gMMUserIDPlayers); {
+        new value[8], valueLength;
+
+        while (!TrieIterEnded(iterator)) {
+            TrieIterGetString(iterator, value, charsmax(value), valueLength);
+            if (equali(value, team)) {
+                counter++;
+            }
+            TrieIterNext(iterator);
+        }
+    }
+    TrieIterDestroy(iterator);
+    return counter;
+}
+
+public CleanMenuData() {
+    new TrieIter:iterator = TrieIterCreate(gMMUserIDPlayers); {
+        new key[32];
+        while (!TrieIterEnded(iterator)) {
+            TrieIterGetKey(iterator, key, charsmax(key));
+            TrieSetString(gMMUserIDPlayers, key, MM_NO_TEAM);
+            TrieIterNext(iterator);
+        }
+    }
+    TrieIterDestroy(iterator);
+
+    gMMMenuOwner = 0;
+    gMMVersusType = "";
 }

--- a/ag/motd_llhl_en.txt
+++ b/ag/motd_llhl_en.txt
@@ -5,7 +5,7 @@ This gamemode is currently used for the Liga Latinoamericana de Half-Life (LLHL)
 # FPS Limiter
 # 'default_fov' Limiter
 # Records a demo automatically when a match is started
-# New command: /unstuck
+# New commands: /unstuck, llhl_match_manager (For administrators only)
 # Sound verification
 # Be able to destroy other players satchels
 # Block nickname and model changes when a game is in progress

--- a/ag/motd_llhl_es.txt
+++ b/ag/motd_llhl_es.txt
@@ -5,7 +5,7 @@ Este modo de juego se usa actualmente para la Liga Latinoamericana de Half-Life 
 # Limitador de FPS
 # Limitador de default_fov
 # Graba demos automaticamente cuando se inicia una partida
-# Nuevo comando: /unstuck
+# Nuevo comandos: /unstuck, llhl_match_manager (Solo para administradores)
 # Verificacion de sonidos
 # Posibilidad de destruir las satchels de otros players
 # No se permiten cambios de nombre y model cuando hay una partida en curso

--- a/ag/motd_llhl_pt.txt
+++ b/ag/motd_llhl_pt.txt
@@ -5,7 +5,7 @@ Este modo de jogo é actualmente utilizado para a Liga Latinoamericana de Half-L
 # Limitador de FPS
 # Limitador do 'default_fov'
 # Uma demonstração e gravada automaticamente quando uma partida começa
-# Novo comando: /unstuck
+# Novo comandos: /unstuck, llhl_match_manager (Apenas para administradores)
 # Verificação do som
 # Possibilidade de destruir as satchels de outros jogadores
 # Não são permitidas mudanças de nome e model quando um jogo está em andamento


### PR DESCRIPTION
New client command: `llhl_match_manager`

Adds a menu for administrators only that allows to start 1vs1, 2vs2, 3vs3, 4vs4, 5vs5 and 6vs6 matches easily, you can also choose the players that will belong to each team (Blue and Red) and start the match.

- If the number of players is less than `sv_ag_start_minplayers` the agstart will not work.
- If the required number of players isn't provided, for example, if you choose 2vs2 and put 3 players on the red team and 2 on the blue team, the match will not start.
- If you try to start the match while there is a countdown (agstart), it will not start.